### PR TITLE
Add new instagram user data in one instagram API call

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -6,7 +6,6 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     else
       instagram_auth(false, Customer)
     end
-
   end
 
   def instagram_auth(is_store, user)
@@ -15,11 +14,10 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     user_instance = user.from_omniauth(request.env["omniauth.auth"])
     session['super_token'] = request.env["omniauth.auth"]["credentials"]["token"]
 
-    getInstagramData(user_instance)
-
     if user_instance.persisted?
-     sign_in_and_redirect user_instance, :event => :authentication #this will throw if user_instance is not activated
-     set_flash_message(:notice, :success, :kind => "Instagram") if is_navigational_format?
+      getInstagramData(user_instance)
+      sign_in_and_redirect user_instance, :event => :authentication #this will throw if user_instance is not activated
+      set_flash_message(:notice, :success, :kind => "Instagram") if is_navigational_format?
     else
      session["devise.instagram_data"] = request.env["omniauth.auth"]
      redirect_to new_user_session_url
@@ -31,16 +29,31 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   end
 
   private
-    def getInstagramData(user)
-      client = Instagram.client(access_token: session['super_token'])
+    def getInstagramData(user_instance)
+      if user_instance.email.blank?
+        client = Instagram.client(access_token: session['super_token'])
 
-      user.update(
-        instagram_id:       client.user.id,
-        image:              client.user.profile_picture,
-        instagram_account:  client.user.username,
-        slug:               client.user.username,
-        user_token:         session['super_token']
-      )
+        user_instance.update(
+          instagram_id:       client.user.id,
+          image:              client.user.profile_picture,
+          instagram_account:  client.user.username,
+          slug:               client.user.username,
+          user_token:         session['super_token'],
+          details:            fill_data(client, user_instance)
+        )
+      end
+    end
+
+    def fill_data(client, user)
+      details = Hash.new
+      if user.type == "Store"
+        details["info"] = client.user.bio
+        details["name"] = client.user.full_name
+        details["facebook"] = client.user.website.split('/')[-1] if client.user.website.include? "facebook"
+      else
+        details["full_name"] = client.user.full_name
+      end
+      details
     end
 
 end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -30,7 +30,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
   private
     def getInstagramData(user_instance)
-      if user_instance.email.blank?
+      if user_instance.slug.blank?
         client = Instagram.client(access_token: session['super_token'])
 
         user_instance.update(


### PR DESCRIPTION
When a new user login, in the edit form the app will display the user instagram data: name, bio, website

This closes #213
